### PR TITLE
fix: make -m/--mode a required argument

### DIFF
--- a/src/flexidot/utils/args.py
+++ b/src/flexidot/utils/args.py
@@ -82,7 +82,8 @@ def parse_args():
         '--mode',
         action='append',
         choices=['0', '1', '2'],
-        help='Mode of FlexiDot dotplotting. 0 = self [default], 1 = paired, 2 = poly (matrix with all-against-all dotplots). Call -m multiple times to run multiple modes.',
+        required=True,
+        help='Mode of FlexiDot dotplotting. 0 = self, 1 = paired, 2 = poly (matrix with all-against-all dotplots). Call -m multiple times to run multiple modes.',
     )
     parser.add_argument(
         '-t',


### PR DESCRIPTION
## Summary

When no `-m` flag is provided, `args.mode` is `None` (since `action='append'` defaults to `None` rather than an empty list). This causes a `TypeError: 'NoneType' object is not iterable` in `print_summary()` at line 87 of `utils/checks.py`.

## Changes

- Add `required=True` to the `-m/--mode` argument in `parse_args()`
- Remove misleading `[default]` from the help text for mode 0 (there is no default when the argument is required)

## Behavior

Before:
```
$ flexidot -i input.fasta
TypeError: 'NoneType' object is not iterable
```

After:
```
$ flexidot -i input.fasta
usage: flexidot [-h] ... -m {0,1,2} ...
flexidot: error: the following arguments are required: -m/--mode
```

## Test Plan

- `flexidot -i input.fasta` without `-m`: now shows a clear argparse error instead of crashing
- `flexidot -i input.fasta -m 0`: unchanged behavior
- `flexidot -i input.fasta -m 0 -m 2`: multiple modes still work via `action='append'`

Fixes #32